### PR TITLE
fix(prompts): Fix word choices

### DIFF
--- a/prompts/master_prompt.md
+++ b/prompts/master_prompt.md
@@ -2,9 +2,34 @@ ROLE: Expert academic translator of Classical Islamic texts; prioritize accuracy
 CRITICAL NEGATIONS: 1. NO SANITIZATION (Do not soften polemics). 2. NO META-TALK (Output translation only). 3. NO MARKDOWN (Plain text only). 4. NO EMENDATION. 5. NO INFERENCE. 6. NO RESTRUCTURING. 7. NO OPAQUE TRANSLITERATION (Must translate phrases). 8. NO INVENTED SEGMENTS (Do not create, modify, or "continue" segment IDs. Output IDs verbatim exactly as they appear in the source input/metadata. Alphabetic suffixes (e.g., P5511a) are allowed IF AND ONLY IF that exact ID appears in the source. Any ID not present verbatim in the source is INVENTED. EXAMPLE: If P5803b ends with a questioner line, that line stays under P5803b — do NOT invent P5803c. If an expected ID is missing from the source, output: "ID - [MISSING]".)
 RULES: NO ARABIC SCRIPT (Except ﷺ). Plain text only. DEFINITION RULE: On first occurrence, transliterated technical terms (e.g., bidʿah) MUST be defined: "translit (English)". Preserve Segment ID. Translate meaning/intent. No inference. No extra fields. Parentheses: Allowed IF present in source OR for (a) technical definitions, (b) dates, (c) book codes.
 WORD CHOICE (Allah vs god):
-- If the source uses الله, translate it as Allah (never "God").
+- If the source uses الله, output Allah (exact spelling: A-l-l-a-h; no diacritics). Never "God" / "god" / "Allāh". (This is the only exception to ALA-LC diacritics.)
+- DO NOT convert Allah-based formulae into English “God …” idioms. Forbidden outputs include (any casing/punctuation), including common variants:
+  - God willing / if God wills / should God will
+  - By God / I swear by God
+  - Praise be to God / thanks be to God / all praise is due to God / praise belongs to God
+  - God knows best / God knows
+  - God forbid
+  - O God
+  - In the name of God
+  - God Almighty / Almighty God / God Most High
+  - By God's grace / By God’s grace
+  - God's ... / God’s ... / ... of God / mercy of God / the mercy of God
+- For the locked items listed under LOCKED FORMULAE below: you MUST output the locked transliteration exactly (no translation).
+- For other phrases containing الله that are NOT in the locked list: translate normally, but the output must contain "Allah" (never "God").
 - Use god/gods (lowercase) only for false gods/deities or when the Arabic uses إله/آلهة in a non-Allah sense.
 - Do not “upgrade” god -> God unless the source is explicitly referring to a specific non-Islamic deity as a proper name.
+LOCKED FORMULAE (Do NOT translate):
+- These are common Muslim greetings/core invocations. Output them exactly as written below (Latin letters only + diacritics where shown).
+- CHECK THIS LIST FIRST. If a phrase matches, output the transliteration EXACTLY (no translation, no paraphrase).
+- They are allowed to remain as multi-word transliteration with NO English gloss.
+- This section is a HARD, EXPLICIT EXCEPTION for these locked formulae ONLY. It SUPERSEDES all conflicting rules, including:
+  - CRITICAL NEGATIONS #7: "NO OPAQUE TRANSLITERATION (Must translate phrases)."
+  - TRANSLITERATION & TERMS #2: "Do NOT output multi-word transliterations without immediate English translation."
+- Locked formulae (implement exactly):
+  - Greetings: al-salāmu ʿalaykum ; wa ʿalaykum al-salām
+  - Invocations: in shāʾ Allah ; subḥān Allah ; al-ḥamdu li-Allah ; Allahu akbar ; lā ilāha illā Allah ; astaghfiru Allah
+- DO NOT translate these into English. Forbidden English equivalents include (not exhaustive): "peace be upon you", "God willing", "praise be to God", "glory be to God", "Allah is Greatest".
+- Note: this lock is intentionally narrow. Other phrases (e.g., "Jazāk Allahu khayr") may be translated normally.
 REGISTER (Modern English):
 - Use modern academic English. Do NOT use archaic/Biblical register words: thee, thou, thine, thy, verily, shalt, hast, art (as "are"), whence, henceforth.
 - Prefer modern auxiliaries and phrasing (will/would, you/your) unless the source itself is quoting an old English translation verbatim.

--- a/src/prompts.test.ts
+++ b/src/prompts.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, test } from 'bun:test';
 import type { PromptId, StackedPrompt } from './prompts';
 import { getMasterPrompt, getPrompt, getPromptIds, getPrompts, getStackedPrompt, stackPrompts } from './prompts';
@@ -97,5 +99,13 @@ describe('getMasterPrompt', () => {
         const content = getMasterPrompt();
         expect(content).toContain('ROLE:');
         expect(content).toContain('CRITICAL NEGATIONS:');
+    });
+
+    test('should include the LOCKED FORMULAE section', () => {
+        const masterPromptPath = join(process.cwd(), 'prompts', 'master_prompt.md');
+        const content = readFileSync(masterPromptPath, 'utf8');
+        expect(content).toContain('LOCKED FORMULAE (Do NOT translate):');
+        expect(content).toContain('al-salāmu ʿalaykum');
+        expect(content).toContain('in shāʾ Allah');
     });
 });


### PR DESCRIPTION
---
name: Word-choice prompt hardening
overview: Analyze all word-choice failure dumps and harden the master prompt to prevent “God” drift for الله-based invocations while introducing a locked set of common Muslim formulae that must remain transliterated.
todos:
  - id: analyze-word-choice-dumps
    content: Parse all `bug_reports/word-choice/*.txt` and extract failure patterns + likely root causes
    status: completed
  - id: write-synthesis-and-diff
    content: Draft a markdown synthesis report with a concrete prompt diff for `prompts/master_prompt.md`
    status: completed
    dependencies:
      - analyze-word-choice-dumps
  - id: prepare-peer-review-packet
    content: Create a markdown peer review packet (modeled after `AI_REVIEW_PROMPT.md`) containing updated prompt text and reviewer questions
    status: completed
    dependencies:
      - write-synthesis-and-diff
  - id: apply-master-prompt-update
    content: Edit `prompts/master_prompt.md` to add locked formulae + hard negations; keep `encyclopedia_mixed` unchanged unless collision found
    status: completed
    dependencies:
      - prepare-peer-review-packet
  - id: add-regression-test
    content: Add a small unit test ensuring the new master prompt section is present
    status: completed
    dependencies:
      - apply-master-prompt-update
---

# Word-choice prompt hardening (Allah vs God + locked formulae)

## Scope
- **Primary target**: [`prompts/master_prompt.md`](prompts/master_prompt.md)
- **Secondary audit**: [`prompts/encyclopedia_mixed.md`](prompts/encyclopedia_mixed.md) (ensure no new collision; likely no edits this round)
- **Evidence set**: [`bug_reports/word-choice/`](bug_reports/word-choice)

## What the reports show (problem summary)
- Models repeatedly translate الله-based formulae as **“God …”** even when the prompt says **“If the source uses الله, translate it as Allah (never ‘God’)”**.
- Common drift shapes seen across the folder:
  - **إن شاء الله → “God willing”**
  - **والله → “By God”**
  - **الحمد لله → “praise be to God”**
  - **الله أعلم → “God knows best”**
- Root cause: these are treated by models as *English idioms* (not “deity name choice”), so the existing rule needs (a) **hard negations**, (b) **explicit banned outputs**, and (c) an **explicit exception** to the existing “must translate phrases / multi-word translit must have English” constraints.

## Proposed prompt changes (high-level)
- **Strengthen “Allah vs god”** into a *locked mapping* for Allah-based invocations and oaths:
  - For Arabic containing **الله** in invocations/oaths (e.g., إن شاء الله / والله / الحمد لله / الله أعلم), require **Allah** (never God) and explicitly forbid the common English idioms.
- **Add “LOCKED FORMULAE (do NOT translate)”** per your direction:
  - **Greetings & core invocations** must remain transliteration (Latin only, with diacritics where applicable) and must **override**:
    - `NO OPAQUE TRANSLITERATION (Must translate phrases)`
    - `Do NOT output multi-word transliterations without immediate English translation`
  - Using your selected orthography preference: **ALA-LC diacritics, but keep “Allah” plain**.

## Implementation steps
1. **Write synthesis + proposal report** (new markdown):
   - Summarize all failure patterns found in `bug_reports/word-choice/*`.
   - Include “why the model did this” analysis (idiom/phrase gravity well + rule collision).
   - Provide a **minimal diff** proposal for `master_prompt.md` (before/after blocks).
2. **Create AI peer review packet markdown** (new markdown, patterned after [`AI_REVIEW_PROMPT.md`](AI_REVIEW_PROMPT.md)):
   - Include: context, observed failures, the *exact updated* `master_prompt.md` (and stacked master+encyclopedia excerpt if helpful), and specific reviewer questions (collision risk, token bloat, regressions).
3. **Apply prompt edits**:
   - Update [`prompts/master_prompt.md`](prompts/master_prompt.md) with:
     - Expanded **WORD CHOICE (Allah vs god)** rules (hard negations + banned phrases).
     - New **LOCKED FORMULAE (Do NOT translate)** list (greetings + core invocations) using your chosen spellings.
     - Explicit **override clause** for the two conflicting transliteration rules.
   - Re-check [`prompts/encyclopedia_mixed.md`](prompts/encyclopedia_mixed.md) for any wording that could reintroduce “translate phrases” pressure; only edit if necessary.
4. **Add lightweight regression test**:
   - Update [`src/prompts.test.ts`](src/prompts.test.ts) to assert the master prompt contains the new section header (e.g., `LOCKED FORMULAE`) so future edits can’t silently remove it.
5. **Generate + validate locally**:
   - Run `bun test`.
   - Run `bun run generate` (ensures prompt bundling still works; `.generated/` remains ignored).

## Locked formulae (draft list; will implement exactly)
- **Greetings**: `al-salāmu ʿalaykum`, `wa ʿalaykum al-salām`
- **Invocations**: `in shāʾ Allah`, `subḥān Allah`, `al-ḥamdu li-Allah`, `Allahu akbar`, `lā ilāha illā Allah`, `astaghfiru Allah`

## Deliverables (files)
- `archive/reports/2026-01-16-word-choice/01_synthesis.md` (new)
- `archive/reports/2026-01-16-word-choice/02_peer_review_packet.md` (new)
- Updated: [`prompts/master_prompt.md`](prompts/master_prompt.md)
- Optional/only if needed: [`prompts/encyclopedia_mixed.md`](prompts/encyclopedia_mixed.md)
- Updated: [`src/prompts.test.ts`](src/prompts.test.ts)

## Word-choice prompt hardening (Allah vs God + locked formulae)

### Scope
- **Evidence set**: `bug_reports/word-choice/*.txt`
- **Primary target for fix**: `prompts/master_prompt.md`
- **Secondary audit**: `prompts/encyclopedia_mixed.md` (no changes required for this round)

### What the reports show (failure patterns)
The model repeatedly outputs **“God …”** idioms even when the source contains **الله** and the master prompt says “If the source uses الله, translate it as Allah (never ‘God’).”

Observed drift shapes across the folder:
- **إن شاء الله** → “God willing”
- **والله** → “By God”
- **الحمد لله** → “praise be to God”
- **الله أعلم** → “God knows best”
- Variants and near-variants: **“In the name of God”**, **“O God”**, **“God forbid”**, possessive forms (**“God’s …”**), and capitalization drift.

Second, we also see **spelling drift** in some model outputs:
- The model sometimes outputs **“Allāh”** (diacritic) instead of the desired plain **“Allah”**.

### Root cause (why the model violates the rule)
This is primarily an **idiom/phrase gravity well** problem plus a **rule-collision** problem:
- **Idiom bypass**: models treat “God willing / By God / Praise be to God …” as fixed English idioms for those Arabic formulae, so they do not “think” they are making a deity-name choice (and thus bypass the simple “الله → Allah” mapping).
- **Rule collision**: `NO OPAQUE TRANSLITERATION (Must translate phrases)` and `Do NOT output multi-word transliterations without immediate English translation` create pressure against leaving formulae untranslated. This pushes the model toward idiomatic English renderings.
- **Orthography ambiguity**: “Use full ALA-LC” can tempt some models into ALA-LC-style **Allāh**, conflicting with the user’s requested **Allah (plain)**.

### Fix goals (constraints)
- **Hard forbid** the common “God …” idioms when the source includes **الله** (especially in formulae/oaths).
- Add a small, explicit **LOCKED FORMULAE (do NOT translate)** list for greetings & core invocations, and make it an explicit override to the two transliteration constraints.
- Ensure orthography: **ALA-LC diacritics where applicable, but keep “Allah” plain** (never “Allāh”).
- Keep changes minimal and localized to `master_prompt.md`.

### Proposed change (minimal `master_prompt.md` diff)

```diff
 WORD CHOICE (Allah vs god):
- - If the source uses الله, translate it as Allah (never "God").
+ - If the source uses الله, output **Allah** (exact spelling: A-l-l-a-h). Never "God" / "god" / "Allāh".
+ - DO NOT convert Allah-based formulae into English “God …” idioms. Forbidden outputs include (case-insensitive):
+   - "God willing", "By God", "Praise be to God", "God knows best", "God forbid", "O God", "In the name of God", "God's ..."
+ - For oaths/invocations that contain الله (e.g., والله / إن شاء الله / الحمد لله / الله أعلم), either:
+   - keep the Arabic formula as a LOCKED FORMULA (see below), OR
+   - translate it, but it must contain "Allah" (not "God").
   - Use god/gods (lowercase) only for false gods/deities or when the Arabic uses إله/آلهة in a non-Allah sense.
   - Do not “upgrade” god -> God unless the source is explicitly referring to a specific non-Islamic deity as a proper name.

+ LOCKED FORMULAE (Do NOT translate):
+ - These are common Muslim greetings/core invocations. Output them exactly as written below (Latin letters only + diacritics where shown).
+ - They are allowed to remain as multi-word transliteration with NO English gloss.
+ - This section OVERRIDES:
+   - "NO OPAQUE TRANSLITERATION (Must translate phrases)"
+   - "Do NOT output multi-word transliterations without immediate English translation."
+ - Locked formulae (implement exactly):
+   - Greetings: al-salāmu ʿalaykum ; wa ʿalaykum al-salām
+   - Invocations: in shāʾ Allah ; subḥān Allah ; al-ḥamdu li-Allah ; Allahu akbar ; lā ilāha illā Allah ; astaghfiru Allah
+ - DO NOT translate these into English (e.g., do not output "peace be upon you", "God willing", "praise be to God", etc.).
+ - Note: this lock is intentionally narrow. Other phrases (e.g., "Jazāk Allahu khayr") may be translated normally.
```

### Risk assessment / regressions to watch
- **Risk: “Allahu akbar” and “lā ilāha illā Allah” containment**: these are frequent; locking them may reduce English readability but is explicitly desired. Ensure no other rules reintroduce pressure to translate them.
- **Risk: “multi-word transliteration” rule**: the override must be explicit and adjacent, otherwise models will continue to “resolve” the collision by translating into “God …” idioms.
- **Risk: scope creep**: keep the lock list narrow (exactly per plan) to avoid freezing too many formulae and increasing prompt bloat.


### Addendum: AI agent review synthesis (what they said + what we adopted)

Collective agreement (multiple agents independently)
1) Strengthen the override language
- What agents said (Claude, Gemini, Grok, Nova): “OVERRIDES” can read as soft; make it an explicit, hard exception/precedence rule so models don’t resolve the collision by obeying “must translate phrases.”
- Decision: AGREE.
- Change adopted: “HARD, EXPLICIT EXCEPTION … SUPERSEDES all conflicting rules” + “CHECK THIS LIST FIRST” + scope explicitly limited to the locked list.

2) Remove the “either/or” ambiguity for locked items
- What agents said (Claude, Gemini, Grok): the “either keep locked OR translate with Allah” bullet creates a choice point that models misuse, producing “If Allah wills” instead of the required locked transliteration.
- Decision: AGREE.
- Change adopted: “For the locked items … you MUST output the locked transliteration exactly (no translation). For other الله phrases not locked: translate but must contain Allah.”

3) Expand banned “God …” variants beyond the exact strings in the reports
- What agents said (Claude, Grok, Nova; also Gemini indirectly): add high-frequency paraphrase families such as “… of God”, “God Almighty / God Most High”, “By God’s grace”, “if God wills”, “I swear by God”, and praise variants (“all praise is due to God”).
- Decision: AGREE (token-lean).
- Change adopted: expanded ban list to include these paraphrase families, not just the original exact phrases.

Unique points (raised by one/few agents)
A) Add a backstop banning common English equivalents of the locked items
- What Gemini said: even if something is locked, models sometimes ignore it; explicitly banning “peace be upon you” / “glory be to God” etc. helps.
- Decision: AGREE.
- Change adopted: added “Forbidden English equivalents include (not exhaustive): …” inside the LOCKED FORMULAE section.

B) Basmalah not locked
- What Gemini said: “In the name of …” behavior is ambiguous if Basmalah isn’t locked.
- Decision: OUT OF SCOPE for this round (plan’s locked list is explicit and intentionally narrow).
- Result: we still ban “In the name of God” and allow translating as “In the name of Allah …” when appropriate.

C) ALA-LC micro-adjustment: al-ḥamdu li-llāh
- What Kimi said: adjust al-ḥamdu li-Allah → al-ḥamdu li-llāh for ALA-LC accuracy.
- Decision: DISAGREE FOR NOW (scope/policy conflict).
- Reason: this round explicitly enforces Allah plain spelling and “implement exactly per plan” for the locked list.

Updated fix proposal (final)
- Make LOCKED FORMULAE mandatory (check-first) and an explicit exception to the two conflicting transliteration rules.
- Expand the “God …” ban list to cover common paraphrase families that models use to evade exact-string bans.
- Add a short backstop list of forbidden English equivalents for locked items (to reduce leakage).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined transliteration rules for Arabic-based terms, particularly greetings and religious invocations, ensuring consistent and accurate rendering throughout the system.
  * Enhanced formatting guidelines and terminology standardization for improved handling of multi-word transliterations and complex phrases.

* **Tests**
  * Added comprehensive test coverage to verify proper transliteration rule implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->