### PR TITLE
fix(prompts): Fix arabic leak

### DIFF
--- a/prompts/master_prompt.md
+++ b/prompts/master_prompt.md
@@ -1,6 +1,12 @@
 ROLE: Expert academic translator of Classical Islamic texts; prioritize accuracy and structure over fluency.
 CRITICAL NEGATIONS: 1. NO SANITIZATION (Do not soften polemics). 2. NO META-TALK (Output translation only). 3. NO MARKDOWN (Plain text only). 4. NO EMENDATION. 5. NO INFERENCE. 6. NO RESTRUCTURING. 7. NO OPAQUE TRANSLITERATION (Must translate phrases). 8. NO INVENTED SEGMENTS (Do not create, modify, or "continue" segment IDs. Output IDs verbatim exactly as they appear in the source input/metadata. Alphabetic suffixes (e.g., P5511a) are allowed IF AND ONLY IF that exact ID appears in the source. Any ID not present verbatim in the source is INVENTED. EXAMPLE: If P5803b ends with a questioner line, that line stays under P5803b — do NOT invent P5803c. If an expected ID is missing from the source, output: "ID - [MISSING]".)
 RULES: NO ARABIC SCRIPT (Except ﷺ). Plain text only. DEFINITION RULE: On first occurrence, transliterated technical terms (e.g., bidʿah) MUST be defined: "translit (English)". Preserve Segment ID. Translate meaning/intent. No inference. No extra fields. Parentheses: Allowed IF present in source OR for (a) technical definitions, (b) dates, (c) book codes.
+ARABIC LEAK (Hard ban):
+- SCRIPT LOCK: Output must be 100% Latin script (ASCII + ALA-LC diacritics like ā ī ū ḥ ṣ ḍ ṭ ẓ ʿ ʾ). These diacritics are allowed/required and are NOT Arabic script.
+- STRICT BAN: Arabic script codepoints (letters, Arabic-Indic numerals ٠-٩, punctuation like ، ؟ ؛ « » , tatweel ـ, and Arabic presentation forms) are forbidden everywhere in output (even inside quotes/brackets/parentheses/citations), except ﷺ.
+- NO CITATIONS/BILINGUAL: Do NOT paste Arabic source text anywhere (no quotes, no citations, no bilingual Arabic+English output). Translate into English only.
+- NO MIXED-SCRIPT: Never output a token that mixes Latin and Arabic characters (example: ʿĪد). Rewrite contaminated names/terms fully in Latin ALA-LC.
+- ZERO ARABIC: Output must contain ZERO Arabic script characters (except ﷺ). If any Arabic appears, delete it and rewrite until none remain.
 WORD CHOICE (Allah vs god):
 - If the source uses الله, output Allah (exact spelling: A-l-l-a-h; no diacritics). Never "God" / "god" / "Allāh". (This is the only exception to ALA-LC diacritics.)
 - DO NOT convert Allah-based formulae into English “God …” idioms. Forbidden outputs include (any casing/punctuation), including common variants:


### PR DESCRIPTION
## Arabic-leak prompt hardening (Arabic script bleed + mixed-script tokens)

### Scope
- Evidence set: bug_reports/arabic-leak/{1.txt,2.txt,3.txt}
- Prompt stack used in all cases: prompts/master_prompt.md + prompts/encyclopedia_mixed.md
- Primary target for fix: prompts/master_prompt.md (global rule layer)
- Secondary audit: prompts/encyclopedia_mixed.md (no changes expected this round)

### What the reports show (failure patterns)
1) Full Arabic source copied into output
- 1.txt, P225856a: an Arabic paragraph was emitted directly in the translation output instead of being translated.

2) Arabic verses included inline “for citation”
- 2.txt, P225903b: Arabic Qurʾanic verse text appears in the English output (the model outputs Arabic + an English rendering).

3) Mixed-script contamination inside “transliteration”
- 3.txt, P164336: ʿĪد: contains Arabic letter(s) embedded in a Latin transliteration token.
- 3.txt, P164338: ʿĪد ʿAbbāsِي: contains Arabic letters embedded inside a name.

### Root cause (why the model violates the rule)
Despite the master prompt already saying “NO ARABIC SCRIPT (Except ﷺ)”, models still leak Arabic in two common ways:
- Quote/citation bypass: models treat Arabic verse text (or Arabic quotes) as allowable “source citation” and include it verbatim.
- Copy-paste + mixed-script drift: while attempting ALA-LC transliteration, the model copies Arabic characters from the source and accidentally embeds them inside Latin tokens (worst-case: a token that visually looks transliterated but contains Arabic codepoints).

### Fix goals (constraints)
- Hard-prevent Arabic script from appearing anywhere in output (except ﷺ), including:
  - inside quotes, parentheses, brackets, angle quotes, and “verse citation” blocks
  - inside transliterated names/terms (no mixed-script tokens)
- Keep changes minimal and localized to prompts/master_prompt.md.

### Proposed change (minimal prompts/master_prompt.md diff)

Add a dedicated “ARABIC LEAK (hard ban + self-check)” block immediately after the existing “RULES: NO ARABIC SCRIPT (Except ﷺ)” line.

```diff
 RULES: NO ARABIC SCRIPT (Except ﷺ). Plain text only. ...
+ARABIC LEAK (Hard ban):
+- Transliteration means Latin letters only (ALA-LC with diacritics). Arabic script is forbidden everywhere in output (even inside quotes/brackets/parentheses), except ﷺ.
+- Do NOT paste Arabic source text as a quote/citation. If the source contains Qurʾanic/ḥadīth Arabic, translate it into English; do not include Arabic.
+- NEVER output mixed-script tokens (Latin + Arabic letters in the same word). If any Arabic character appears in a name/term, rewrite it fully in Latin ALA-LC (or English-only if unsure).
+- Final self-check: before emitting your answer, scan for any Arabic characters. If any are present (other than ﷺ), remove them and rewrite in Latin/English until none remain.
```

### Risk assessment / regressions to watch
- Over-correction: model may become overly afraid of diacritics (Latin Extended) and drop ALA-LC diacritics. Mitigation: explicitly define Arabic script vs Latin Extended; allow diacritics; only ban Arabic codepoints.
- Citation behavior: some models like to include Arabic verses “for accuracy”. The fix must explicitly forbid Arabic even inside quotes to block that bypass.

### Addendum: AI agent review synthesis (agreements/disagreements + updated proposal)

Collective agreement (multiple agents independently)
1) Clarify “Latin vs Arabic” to prevent diacritic regression
- Agents (Claude, Gemini, Nova, Kimi, Grok): “Latin letters only” can be misread as ASCII-only; explicitly say Latin + Latin Extended ALA-LC diacritics are allowed/required, while Arabic codepoints are forbidden.
- Decision: AGREE.
- Change: explicitly list allowed ALA-LC diacritics (ā ī ū ḥ ṣ ḍ ṭ ẓ ʿ ʾ) and distinguish them from Arabic script codepoints.

2) Close the citation / bilingual-output loophole
- Agents (Claude, Nova, Kimi): models may output Arabic + English together “for verification.” Ban bilingual output and ban Arabic in quotes/citations explicitly.
- Decision: AGREE.
- Change: “NO Arabic anywhere, even in quotes/citations/brackets/parentheses; NO bilingual output (Arabic + English). Translate to English only.”

3) Expand coverage to Arabic punctuation/numerals/presentation forms
- Agents (Gemini, Nova, Grok): leaks can be punctuation (، ؟ ؛ « »), Arabic-Indic numerals (٠-٩), tatweel (ـ), and presentation forms.
- Decision: AGREE (token-lean).
- Change: mention these categories explicitly in the ban (not just “letters”).

Points of disagreement / scoped decisions
1) “English-only if unsure” escape hatch
- Claude strongly recommends removing it to avoid regressions (Eid/Abbas instead of ʿĪd/ʿAbbās).
- Decision: AGREE with removal.
- Change: remove “(or English-only if unsure)” from the mixed-script remediation; require rewriting in Latin ALA-LC.

2) “Self-check” usefulness
- Gemini notes “final self-check” is often ineffective in single-pass generation.
- Others prefer keeping it as an extra guardrail, but making it more actionable/forceful.
- Decision: KEEP but tighten.
- Change: rephrase as a hard constraint: “Output must contain ZERO Arabic script (except ﷺ); if any appears, delete and rewrite.”

Implementation update (what we will change in the prompt now)
- Refactor the Arabic-leak instruction out of the dense RULES run-on into its own small block for better model parsing.
- Update the block to: protect ALA-LC diacritics, ban Arabic punctuation/numerals/presentation forms, ban bilingual output, remove the “English-only” escape hatch, and strengthen the zero-Arabic constraint.

PEER REVIEW PACKET: Arabic script leakage (arabic_leak)

Goal
- Prevent any Arabic script from appearing in model output (except ﷺ), including:
  - full Arabic lines copied into output
  - Arabic Qurʾanic verses pasted inline “for citation”
  - mixed-script tokens like ʿĪد or ʿAbbāsِي

What you are given (attachments)
- prompts/master_prompt.md (current; proposed to be edited)
- prompts/encyclopedia_mixed.md (stacked addon; check for collisions)
- bug_reports/arabic-leak/examples_consolidated.txt (small evidence bundle consolidated from the reports)

Context (what we saw)
- 1.txt: P225856a output contains a large Arabic paragraph copied into output.
- 2.txt: P225903b output includes Arabic verse text inline alongside English.
- 3.txt: P164336 / P164338 contain mixed-script “transliteration” tokens.

Root cause hypothesis
- Models treat Arabic verse text as allowed “citation/quote” even under “no Arabic script.”
- Transliteration sometimes copies Arabic codepoints into Latin tokens, creating mixed-script words.

Proposed fix (target: prompts/master_prompt.md)
Add a small explicit block right after the existing “NO ARABIC SCRIPT (Except ﷺ)” rule:

ARABIC LEAK (Hard ban):
- Transliteration means Latin letters only (ALA-LC with diacritics). Arabic script is forbidden everywhere in output (even inside quotes/brackets/parentheses), except ﷺ.
- Do NOT paste Arabic source text as a quote/citation. If the source contains Qurʾanic/ḥadīth Arabic, translate it into English; do not include Arabic.
- NEVER output mixed-script tokens (Latin + Arabic letters in the same word). If any Arabic character appears in a name/term, rewrite it fully in Latin ALA-LC (or English-only if unsure).
- Final self-check: before emitting your answer, scan for any Arabic characters. If any are present (other than ﷺ), remove them and rewrite in Latin/English until none remain.

Reviewer questions
1) Is the “no Arabic anywhere (even in quotes)” phrasing strong enough to stop the verse-citation bypass?
2) Is the “mixed-script tokens” instruction clear/actionable and narrow enough to not harm normal ALA-LC output?
3) Any high-frequency edge cases we missed (e.g., Arabic tatweel, Arabic presentation forms, or diacritics) that should be mentioned without bloating tokens?
4) Will this create regressions with ALA-LC diacritics (Latin Extended) by making models fear diacritics? If so, suggest a token-lean clarification.
5) Suggest the smallest wording improvements to maximize compliance while staying token-lean.


[examples_consolidated.txt](https://github.com/user-attachments/files/24681541/examples_consolidated.txt)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Modified text processing rules for improved consistency in script handling and transliteration formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->